### PR TITLE
Update awa.tex

### DIFF
--- a/ode/awa.tex
+++ b/ode/awa.tex
@@ -49,7 +49,7 @@
     \begin{pmatrix}
       u_0'(t) - u_1(t) \\
       u_1'(t) - u_2(t) \\
-      \cdots\\
+      \vdots\\
       u_{n-2}'(t) - u_{n-1}(t) \\
       F\bigl(t, u_0(t),u_1(t),\dots,u_{n-1}(t), u_{n-1}'(t)\bigr)
     \end{pmatrix}
@@ -62,10 +62,10 @@
   \begin{gather}
     \label{eq:awa:13a}
     \begin{pmatrix}
-      u_0'(t) - u_1(t) \\
-      u_1'(t) - u_2(t) \\
-      \cdots\\
-      u_{n-2}'(t) - u_{n-1}(t) \\
+      u_0'(t) \\
+      u_1'(t) \\
+      \vdots\\
+      u_{n-2}'(t) \\
       u_{n-1}'
     \end{pmatrix}
     =


### PR DESCRIPTION
cdots einheitlich in vdots, den Schreibfehler von 1.5 auf 1.6 korrigiert.

In Zeile 55 steht "F\bigl(t, u_0(t),u_1(t),\dots,u_{n-1}(t), u_{n-1}'(t)\bigr)", meinen Sie "u_{n-1}'(t) - F\bigl(t, u_0(t),u_1(t),\dots,u_{n-1}(t) \bigr)" ?