### PR TITLE
Update awa.tex

### DIFF
--- a/ode/awa.tex
+++ b/ode/awa.tex
@@ -633,21 +633,21 @@ theory of ordinary differential equations.
     & = \left| u_0 - u_0 + \int\limits_{0}^t (f(s,u(s)) - f(s,v(s))) \ds \right| \\
     & \le \int\limits_{0}^t \left| f\bigl(s,u(s)\bigr) - f\bigl((s,v(s)\bigr) \right| \ds \\
     & \le \int\limits_{0}^t L |u(s) - v(s)| \underbrace{e^{-2 L s} e^{2 L s}}_{= 1} \ds \\
-    & \le L |u-v|_e \int\limits_{0}^t e^{2 L s} \ds \\
-    & = L |u-v|_e \frac{e^{2 L t}}{2 L} \\
-    & \le \frac12 e^{2 L t}|u-v|_e.
+    & \le L \norm{u-v}_e \int\limits_{0}^t e^{2 L s} \ds \\
+    & = L \norm{u-v}_e \frac{e^{2 L t} - 1}{2 L} \\
+    & \le \frac12 e^{2 L t} \norm{u-v}_e.
   \end{align*}
 
   It follows   
   \begin{gather*}
-    e^{-2 L t}|F(u)(t) - F(v)(t)| \le \frac12 |u-v|_e,
+    e^{-2 L t}|F(u)(t) - F(v)(t)| \le \frac12 \norm{u-v}_e,
   \end{gather*}
   for all $t$ and we observe:
   \begin{gather*}
-    |F(u)(t) - F(v)(t)|_e \le \frac12 |u-v|_e.
+    |F(u)(t) - F(v)(t)|_e \le \frac12 \norm{u-v}_e.
   \end{gather*}
   Thus, we have shown that $F$ is a contraction on the space of the
-  continuous functions with the norm $|.|_e$.  Therefore, we can apply
+  continuous functions with the norm $\norm{.}_e$.  Therefore, we can apply
   the \putindex{Banach fixed-point theorem}, concluding that $F$ has
   exactly one fixed-point. This proves the theorem.
 \end{proof}


### PR DESCRIPTION
\norm{.}_e statt |.|_e geschrieben, wo es auftauchte. Im Integral hatte sich ein -1 rausgeschlichen, das Argument stimmt aber noch.